### PR TITLE
docs: update Mintlify config and fix version compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/*/CLAUDE.md
+!./CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Mintlify-powered documentation site for OpenCart language packages, maintained by DESIGN4PRO. The site provides documentation for installing, building, and translating OpenCart language packs.
+
+## Documentation Structure
+
+```
+docs/
+├── docs.json              # Mintlify configuration
+├── index.mdx              # Main landing page (English)
+├── overview.mdx           # Overview page
+├── languages/             # Language overview pages
+│   └── polish.mdx         # Polish language documentation
+├── getting-started/       # English getting started guides
+│   ├── installation.mdx
+│   ├── purchase.mdx
+│   └── support.mdx
+├── development/           # Development guides
+│   ├── building.mdx
+│   └── translating.mdx
+└── CLAUDE.md
+```
+
+## Commands
+
+### Local Development
+
+```bash
+# Start local development server (Mintlify)
+npx mintlify dev
+```
+
+### Build & Deploy
+
+```bash
+# Build documentation for production
+npx mintlify build
+
+# Start production server
+npx mintlify start
+
+# Deploy to Mintlify
+npx mintlify deploy
+```
+
+### Validation
+
+```bash
+# Check for broken links
+npx mintlify broken-links
+
+# Validate configuration
+npx mintlify validate
+```
+
+## Configuration
+
+The site uses the "maple" theme with primary color `#0096e6`. Navigation is configured in `docs.json` using the **tabs** pattern (recommended by Mintlify): Getting Started, Languages, and Development.
+
+## OpenCart Version
+
+**Only OpenCart 4.1.x is supported.** The source files are located in `../opencart/src/v4.1/`.
+
+## Extension Structure
+
+The extension `oc_language_pl` (Polish Language Pack) is the only extension in this project. Located at:
+- `../opencart/src/v4.1/extension/oc_language_pl/`
+
+Key files:
+- `install.json` - Extension metadata (version 4.1.x only)
+- `admin/` - Admin panel language files
+- `catalog/` - Catalog (storefront) language files
+
+## Multi-Language Support
+
+The documentation supports English (default) and Polish (`/pl/`). When adding new pages:
+1. Create the English version in the root directory
+2. Create the Polish translation in `pl/` directory
+3. Add both to `docs.json` navigation

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Mintlify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# OpenCart Language Packages
+
+Multi-language packages for OpenCart e-commerce platform, developed and maintained by DESIGN4PRO.
+
+## Documentation
+
+Full documentation is available at: **[opencart.design4.pro](https://opencart.design4.pro)**
+
+### Languages
+
+- **Polish (pl-pl)** - Complete translation package for OpenCart 4.1.x
+- More languages coming soon...
+
+### Quick Links
+
+- [Installation Guide](https://opencart.design4.pro/getting-started/installation)
+- [Purchase](https://opencart.design4.pro/getting-started/purchase)
+- [Support](https://opencart.design4.pro/getting-started/support)
+- [Building Packages](https://opencart.design4.pro/development/building)
+- [Translating](https://opencart.design4.pro/development/translating)
+
+## License
+
+See [LICENSE](./LICENSE) file for details.

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/development/building.mdx
+++ b/docs/development/building.mdx
@@ -1,0 +1,170 @@
+---
+title: Building Packages
+description: How to build language packages from source
+sidebar_position: 20
+---
+
+# Building Packages
+
+Learn how to build language packages from source files using the build system.
+
+## Prerequisites
+
+- Node.js 18 or higher
+- npm or yarn package manager
+
+## Installation
+
+<CodeGroup>
+```bash npm
+npm install
+```
+
+```bash yarn
+yarn install
+```
+</CodeGroup>
+
+## Building Packages
+
+### Build All Packages
+
+Build all language packages for the default version:
+
+```bash
+npm run build
+```
+
+### Build Specific Language
+
+Build only a specific language package:
+
+```bash
+npm run build:pl
+```
+
+### Build All Languages
+
+Build all language packages for all versions:
+
+```bash
+npm run build:all
+```
+
+## Output
+
+Built packages are saved to the `packages/` directory:
+
+```
+packages/
+├── pl/
+│   ├── v4.1/
+│   │   └── opencart-core-language-pl-v4.1.ocmod.zip
+│   ├── v4.0/
+│   └── v3/
+├── fr/
+└── ...
+```
+
+<Note>
+Each package is named following the convention: `opencart-core-language-{lang}-{version}.ocmod.zip`
+</Note>
+
+## Package Structure
+
+Each ZIP package contains:
+
+```
+opencart-core-language-{lang}-{version}.ocmod.zip
+├── install.json
+├── admin/
+│   └── language/
+│       ├── en-gb/
+│       └── {language}/
+└── catalog/
+    └── language/
+        ├── en-gb/
+        └── {language}/
+```
+
+## Extension Template
+
+A reusable template for creating OpenCart language extensions is located at:
+
+```
+sources/v4.1/extension/template/design4pro/
+```
+
+### Template Structure
+
+```
+design4pro/
+├── install.json
+└── admin/
+    ├── controller/dashboard/language_xx.php
+    ├── model/dashboard/language_xx.php    # Configurable constants
+    ├── view/template/dashboard/language_xx.twig
+    └── language/
+        ├── en-gb/language_xx.php
+        └── pl-pl/language_xx.php
+```
+
+### Using the Template
+
+<Steps>
+  <Step title="Copy Template">
+    Copy the `design4pro/` folder to your new language directory (e.g., `language_de/`)
+  </Step>
+  <Step title="Rename Files">
+    Rename all `language_xx` files to include your language code:
+    - `language_xx.php` → `language_de.php`
+    - `language_xx.twig` → `language_de.twig`
+  </Step>
+  <Step title="Configure Constants">
+    Modify constants in `model/dashboard/language_de.php`:
+    - `LANGUAGE_CODE` - regional format (e.g., `'de-de'`)
+    - `LANGUAGE_NAME` - native language name
+    - `COUNTRY_CODE`, `CURRENCY_CODE`, `TAX_RATE_PERCENT`
+    - `ZONES` - array of provinces/regions
+    - Translation dictionaries
+  </Step>
+  <Step title="Update Language Folder">
+    Rename language folder from `pl-pl` to your code (e.g., `de-de`)
+  </Step>
+  <Step title="Translate">
+    Translate `admin/language/{code}/language_de.php`
+  </Step>
+  <Step title="Update Metadata">
+    Update `install.json` with your language details
+  </Step>
+</Steps>
+
+<Warning>
+Use language code in extension name: `language_pl`, `language_de`, etc. This prevents conflicts when multiple languages are installed.
+</Warning>
+
+## Important Notes
+
+<Tabs>
+  <Tab title="Language Codes">
+    Use regional format for language codes:
+    - Polish: `pl-pl`
+    - German: `de-de`
+    - Spanish: `es-es`
+
+    OpenCart 4.x requires this format for proper language detection.
+  </Tab>
+  <Tab title="Template Features">
+    The template handles:
+    - Language installation
+    - Currency setup
+    - Country configuration
+    - Zone/province setup
+    - Tax rates
+    - Translation dictionaries
+  </Tab>
+</Tabs>
+
+<Check>
+Your language extension package is now ready to install via OpenCart's extension installer.
+</Check>

--- a/docs/development/translating.mdx
+++ b/docs/development/translating.mdx
@@ -1,0 +1,151 @@
+---
+title: Translating
+description: How to translate language files using Claude Code
+sidebar_position: 21
+---
+
+# Translating Language Files
+
+This project uses Claude Code skill for translating OpenCart language files efficiently and accurately.
+
+## Available Languages
+
+<CardGroup cols={3}>
+  <Card title="Polish (pl-pl)" icon="check">
+    Complete translation available
+  </Card>
+  <Card title="French (fr-fr)" icon="hammer">
+    Translation in progress
+  </Card>
+  <Card title="German (de-de)" icon="globe">
+    Coming soon
+  </Card>
+  <Card title="Italian (it-it)" icon="globe">
+    Coming soon
+  </Card>
+  <Card title="Ukrainian (uk-ua)" icon="globe">
+    Coming soon
+  </Card>
+  <Card title="Spanish (es-es)" icon="globe">
+    Coming soon
+  </Card>
+</CardGroup>
+
+## How to Translate
+
+### Using Claude Code Commands
+
+<Steps>
+  <Step title="Open Claude Code">
+    Open Claude Code in the project directory
+  </Step>
+  <Step title="Use Translate Skill">
+    Use the OpenCart Language Translator skill with your desired language and scope
+  </Step>
+  <Step title="Wait for Completion">
+    The agent will process all files and generate translations
+  </Step>
+</Steps>
+
+### Example Commands
+
+Translate admin language files to German:
+
+```
+/translate admin language to german for v4.1
+```
+
+Translate catalog language files to French:
+
+```
+/translate catalog language files to french
+```
+
+### Direct Requests
+
+You can also ask directly in natural language:
+
+- "Przetłumacz pliki językowe admin na niemiecki dla v4.1"
+- "Translate catalog language files to French"
+- "Translate all extension files to Spanish"
+
+<Info>
+The translation agent uses AI to provide high-quality, context-aware translations for all language files.
+</Info>
+
+## Translation Workflow
+
+<Steps>
+  <Step title="Source Files">
+    English source files are located in `sources/{version}/`
+  </Step>
+  <Step title="Translation Process">
+    Claude Code processes each file and generates translations using AI
+  </Step>
+  <Step title="Translation Output">
+    Translated files are saved to `translations/{lang}/{version}/`
+  </Step>
+  <Step title="Build Package">
+    Use `npm run build` to create the package
+  </Step>
+</Steps>
+
+## File Structure
+
+### Source Files
+
+```
+sources/
+├── v4.1/
+│   ├── admin/           # Admin panel English files
+│   │   ├── catalog/
+│   │   ├── common/
+│   │   └── ...
+│   └── catalog/         # Catalog English files
+│       ├── account/
+│       ├── checkout/
+│       └── ...
+├── v4.0/
+└── v3/
+```
+
+### Translated Files
+
+```
+translations/
+├── pl/
+│   ├── v4.1/
+│   │   ├── admin/      # Polish admin translations
+│   │   └── catalog/    # Polish catalog translations
+│   ├── v4.0/
+│   └── v3/
+├── fr/
+└── ...
+```
+
+## Translation Coverage
+
+| Component | Status |
+|-----------|--------|
+| Admin Panel | Full coverage |
+| Catalog | Full coverage |
+| Extensions | Full coverage |
+| System Messages | Full coverage |
+
+<Check>
+All translations maintain 100% compatibility with source files.
+</Check>
+
+## Best Practices
+
+<Tip>
+When adding new translations:
+1. Always use the regional language code format (pl-pl, de-de, es-es)
+2. Follow OpenCart's existing translation conventions
+3. Test translations in both admin and catalog
+4. Build and install the package to verify
+</Tip>
+
+## Need Help?
+
+For questions about translations or to contribute new languages, contact: dev@design4.pro

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "OpenCart Languages",
+  "description": "Multi-language packages for OpenCart e-commerce platform",
+  "theme": "maple",
+  "languages": [
+    "en",
+    "pl"
+  ],
+  "colors": {
+    "primary": "#0096e6",
+    "light": "#f0f7fc",
+    "dark": "#1a1a2e"
+  },
+  "logo": {
+    "light": "/logo-light.svg",
+    "dark": "/logo-dark.svg"
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "href": "https://github.com/design4pro/opencart",
+        "target": "_blank"
+      }
+    ]
+  },
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Getting Started",
+        "icon": "rocket",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "overview",
+              "getting-started/installation",
+              "getting-started/purchase",
+              "getting-started/support"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Languages",
+        "icon": "globe",
+        "groups": [
+          {
+            "group": "Languages",
+            "pages": [
+              "languages/polish"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Development",
+        "icon": "hammer",
+        "groups": [
+          {
+            "group": "Development",
+            "pages": [
+              "development/building",
+              "development/translating"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/design4pro/opencart"
+    }
+  }
+}

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,19 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.06145 23.1079C5.26816 22.3769 -3.39077 20.6274 1.4173 5.06384C9.6344 6.09939 16.9728 14.0644 9.06145 23.1079Z" fill="url(#paint0_linear_17557_2021)"/>
+<path d="M8.91928 23.0939C5.27642 21.2223 0.78371 4.20891 17.0071 0C20.7569 7.19341 19.6212 16.5452 8.91928 23.0939Z" fill="url(#paint1_linear_17557_2021)"/>
+<path d="M8.91388 23.0788C8.73534 19.8817 10.1585 9.08525 23.5699 13.1107C23.1812 20.1229 18.984 26.4182 8.91388 23.0788Z" fill="url(#paint2_linear_17557_2021)"/>
+<defs>
+<linearGradient id="paint0_linear_17557_2021" x1="3.77557" y1="5.91571" x2="5.23185" y2="21.5589" gradientUnits="userSpaceOnUse">
+<stop stop-color="#18E299"/>
+<stop offset="1" stop-color="#15803D"/>
+</linearGradient>
+<linearGradient id="paint1_linear_17557_2021" x1="12.1711" y1="-0.718425" x2="10.1897" y2="22.9832" gradientUnits="userSpaceOnUse">
+<stop stop-color="#16A34A"/>
+<stop offset="1" stop-color="#4ADE80"/>
+</linearGradient>
+<linearGradient id="paint2_linear_17557_2021" x1="23.1327" y1="15.353" x2="9.33841" y2="18.5196" gradientUnits="userSpaceOnUse">
+<stop stop-color="#4ADE80"/>
+<stop offset="1" stop-color="#0D9373"/>
+</linearGradient>
+</defs>
+</svg>

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,0 +1,107 @@
+---
+title: Installation
+description: How to install OpenCart language packages
+sidebar_position: 2
+---
+
+# Installation
+
+## Requirements
+
+- OpenCart 4.1.x
+- Admin access to your OpenCart installation
+
+<Info>
+We recommend using the extension installer method for easiest installation and future updates.
+</Info>
+
+## Installation Methods
+
+### Method 1: Extension Installer (Recommended)
+
+<Steps>
+  <Step title="Download the Language Package">
+    Download the language package (.ocmod.zip file) from the packages directory
+  </Step>
+  <Step title="Upload to OpenCart">
+    Go to **Extensions > Installer** in your admin panel
+  </Step>
+  <Step title="Install the Package">
+    Click the **Upload** button and select the downloaded ZIP file
+  </Step>
+  <Step title="Enable the Language">
+    Go to **Extensions > Extensions > Languages**, find your language, and click Install
+  </Step>
+  <Step title="Configure Settings">
+    Click Edit to configure the language settings as needed
+  </Step>
+</Steps>
+
+### Method 2: Manual Installation
+
+<Steps>
+  <Step title="Extract the ZIP File">
+    Extract the downloaded ZIP file to your local computer
+  </Step>
+  <Step title="Upload Files">
+    Upload the `admin` and `catalog` folders to your OpenCart root directory
+  </Step>
+  <Step title="Install Language">
+    Go to **Extensions > Extensions > Languages** and install your language
+  </Step>
+  <Step title="Configure Settings">
+    Click Edit to configure the language settings
+  </Step>
+</Steps>
+
+<Warning>
+Manual installation may cause issues with future updates. We recommend using the extension installer method.
+</Warning>
+
+## Configuration
+
+After installation, configure the language:
+
+<Steps>
+  <Step title="Navigate to Languages">
+    Go to **System > Localisation > Languages**
+  </Step>
+  <Step title="Edit Language">
+    Click **Edit** on your new language
+  </Step>
+  <Step title="Enable Language">
+    Set **Status** to Enabled
+  </Step>
+  <Step title="Set Sort Order">
+    Set **Sort Order** to 1 (or your desired order)
+  </Step>
+  <Step title="Save Changes">
+    Click the Save button to apply changes
+  </Step>
+</Steps>
+
+## Setting Default Language
+
+To set your new language as the default store language:
+
+<Steps>
+  <Step title="Open Settings">
+    Go to **System > Settings**
+  </Step>
+  <Step title="Edit Store">
+    Click **Edit** on your store
+  </Step>
+  <Step title="Go to Local Tab">
+    Navigate to the **Local** tab
+  </Step>
+  <Step title="Set Default Language">
+    Set **Language** to your new language
+  </Step>
+  <Step title="Save Settings">
+    Click Save to apply the changes
+  </Step>
+</Steps>
+
+<Check>
+Your language is now installed and configured. The store will display in the new language for all visitors.
+</Check>

--- a/docs/getting-started/purchase.mdx
+++ b/docs/getting-started/purchase.mdx
@@ -1,0 +1,79 @@
+---
+title: Purchase
+description: Purchase language packages from OpenCart Marketplace
+sidebar_position: 3
+---
+
+# Purchase Language Packages
+
+You can obtain our language packages in two ways: through the official OpenCart Marketplace or by direct download.
+
+## OpenCart Marketplace
+
+<Card title="Polish Language Pack" icon="shopping-cart" href="https://www.opencart.com/index.php?route=marketplace extension/info&extension_id=436503" target="_blank">
+  Purchase from OpenCart Marketplace
+</Card>
+
+### Benefits of Marketplace Purchase
+
+<CardGroup cols={2}>
+  <Card title="Easy Updates" icon="refresh">
+    Receive updates directly through the OpenCart extension manager
+  </Card>
+  <Card title="Secure Payment" icon="lock">
+    Secure transactions via OpenCart's payment system
+  </Card>
+  <Card title="License Management" icon="file-text">
+    Automatic license validation and management
+  </Card>
+  <Card title="Support Access" icon="headphones">
+    Priority support for marketplace purchases
+  </Card>
+</CardGroup>
+
+### What You Get
+
+- Full access to the Polish language package
+- Future version updates
+- Extension support
+- Installation assistance
+
+## Direct Download
+
+Download language packages directly from our servers for free:
+
+<Tabs>
+  <Tab title="OpenCart 4.1">
+    [Download Polish language package v4.1](/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 4.0">
+    [Download Polish language package v4.0](/packages/pl/v4.0/opencart-core-language-pl-v4.0.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 3">
+    [Download Polish language package v3](/packages/pl/v3/opencart-core-language-pl-v3.ocmod.zip)
+  </Tab>
+</Tabs>
+
+### Direct Download Features
+
+- Free access to all language packages
+- Manual installation required
+- Self-managed updates
+- Community support via GitHub
+
+<Warning>
+Direct downloads do not include automatic updates. You will need to manually check for and install new versions.
+</Warning>
+
+## Comparison
+
+| Feature | Marketplace | Direct Download |
+|---------|-------------|-----------------|
+| Price | Paid | Free |
+| Auto Updates | Yes | No |
+| Support | Priority | Community |
+| Installation | One-click | Manual |
+
+<Tip>
+Choose the option that best fits your needs. Both provide the same language package content.
+</Tip>

--- a/docs/getting-started/support.mdx
+++ b/docs/getting-started/support.mdx
@@ -1,0 +1,117 @@
+---
+title: Support
+description: Get support and report bugs via GitHub Issues
+sidebar_position: 4
+---
+
+# Support & Bug Reporting
+
+We welcome bug reports and feature requests. Please use GitHub Issues to report any issues you encounter.
+
+## Report a Bug
+
+<Card title="Open GitHub Issues" icon="bug" href="https://github.com/design4pro/opencart/issues" target="_blank">
+  Report bugs and issues
+</Card>
+
+### Before Submitting
+
+<Steps>
+  <Step title="Search Existing Issues">
+    Check if the issue has already been reported
+  </Step>
+  <Step title="Verify the Issue">
+    Confirm the issue exists in the latest version
+  </Step>
+  <Step title="Gather Information">
+    Collect relevant details about your environment
+  </Step>
+</Steps>
+
+### Required Information
+
+When reporting a bug, please include:
+
+<Accordion title="Environment Details">
+- OpenCart version
+- PHP version
+- Web server (Apache/Nginx)
+- Database version
+- Language package version
+</Accordion>
+
+<Accordion title="Issue Description">
+- Clear description of the problem
+- Steps to reproduce
+- Expected vs actual behavior
+</Accordion>
+
+<Accordion title="Screenshots">
+- Relevant screenshots
+- Error messages
+- Console logs (if applicable)
+</Accordion>
+
+### Bug Report Template
+
+```markdown
+**Bug Description**
+[A clear and concise description of what the bug is]
+
+**Environment**
+- OpenCart Version:
+- PHP Version:
+- Language Package Version:
+
+**Steps to Reproduce**
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected Behavior**
+[What you expected to happen]
+
+**Actual Behavior**
+[What actually happened]
+
+**Screenshots**
+[If applicable, add screenshots]
+```
+
+## Feature Requests
+
+<Card title="Request a Feature" icon="lightbulb" href="https://github.com/design4pro/opencart/issues" target="_blank">
+  Submit feature requests
+</Card>
+
+### Feature Request Template
+
+```markdown
+**Feature Description**
+[Clear description of the feature]
+
+**Use Case**
+[Explain why this feature would be useful]
+
+**Proposed Solution**
+[Your idea for implementation]
+```
+
+## Other Support Channels
+
+<CardGroup cols={2}>
+  <Card title="Email Support" icon="mail" href="mailto:dev@design4.pro">
+    For direct inquiries
+  </Card>
+  <Card title="GitHub Repository" icon="github" href="https://github.com/design4pro/opencart" target="_blank">
+    Source code and contributions
+  </Card>
+</CardGroup>
+
+<Warning>
+For security vulnerabilities, please do not report via GitHub Issues. Email security concerns directly to dev@design4.pro.
+</Warning>
+
+<Tip>
+Before submitting a bug report, check the existing issues and pull requests to avoid duplicates.
+</Tip>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,119 @@
+---
+title: Overview
+description: Multi-language packages for OpenCart e-commerce platform
+sidebar_position: 1
+---
+
+# OpenCart Languages
+
+Welcome to the OpenCart Languages documentation. This project provides multi-language packages for OpenCart e-commerce platform, developed and maintained by DESIGN4PRO.
+
+## Supported Languages
+
+<CardGroup cols={3}>
+  <Card title="Polish (pl-pl)" icon="globe" href="/languages/polish">
+    Complete Polish language package for OpenCart 4.1.x
+  </Card>
+  <Card title="French (fr-fr)" icon="globe" badge={{ label: 'Coming Soon', variant: 'warning' }}>
+    French language package - Coming soon
+  </Card>
+  <Card title="German (de-de)" icon="globe" badge={{ label: 'Coming Soon', variant: 'warning' }}>
+    German language package - Coming soon
+  </Card>
+  <Card title="Italian (it-it)" icon="globe" badge={{ label: 'Coming Soon', variant: 'warning' }}>
+    Italian language package - Coming soon
+  </Card>
+  <Card title="Ukrainian (uk-ua)" icon="globe" badge={{ label: 'Coming Soon', variant: 'warning' }}>
+    Ukrainian language package - Coming soon
+  </Card>
+  <Card title="Spanish (es-es)" icon="globe" badge={{ label: 'Coming Soon', variant: 'warning' }}>
+    Spanish language package - Coming soon
+  </Card>
+</CardGroup>
+
+## Supported OpenCart Versions
+
+<Tabs>
+  <Tab title="OpenCart 4.1.x">
+    Current stable version with full language support
+  </Tab>
+  <Tab title="OpenCart 4.0.x">
+    Legacy support available
+  </Tab>
+  <Tab title="OpenCart 3.x">
+    Legacy support available
+  </Tab>
+</Tabs>
+
+## Quick Start
+
+<Steps>
+  <Step title="Download the Language Package">
+    Download the language package for your OpenCart version from the packages directory
+  </Step>
+  <Step title="Install via Extension Installer">
+    Go to Extensions > Installer in your admin panel and upload the ZIP file
+  </Step>
+  <Step title="Configure Language">
+    Go to System > Localisation > Languages and configure the new language
+  </Step>
+  <Step title="Set as Default">
+    Optionally set the new language as default in System > Settings > Local
+  </Step>
+</Steps>
+
+## Features
+
+- Complete translations for admin panel
+- Complete translations for catalog (storefront)
+- Email templates translation
+- Regular updates for new OpenCart versions
+- Professional localization by DESIGN4PRO
+- Reusable extension template for new languages
+
+<Note>
+All language packages include full admin and catalog translations with 100% coverage for maximum compatibility.
+</Note>
+
+## Language Extension Template
+
+A reusable template for creating OpenCart language extensions is available at:
+
+```
+sources/v4.1/extension/template/design4pro/
+```
+
+The template includes:
+
+- Parameterized model with configurable constants
+- Regional language code support (pl-pl, de-de, etc.)
+- Automatic installation of language, currency, country, and zones
+- Translation dictionaries for statuses, options, layouts, and more
+
+<Tip>
+Use the extension template to create your own language packages quickly and consistently.
+</Tip>
+
+See the [Building Packages](/development/building) documentation for details on using the template.
+
+## Purchase
+
+<CardGroup cols={2}>
+  <Card title="OpenCart Marketplace" icon="shopping-cart" href="/getting-started/purchase">
+    Purchase language packages from the official OpenCart Marketplace
+  </Card>
+  <Card title="Direct Download" icon="download" href="/languages/polish">
+    Download language packages directly from our servers
+  </Card>
+</CardGroup>
+
+## Support
+
+<CardGroup cols={2}>
+  <Card title="Report Bugs" icon="bug" href="/getting-started/support">
+    Found an issue? Report bugs via GitHub Issues
+  </Card>
+  <Card title="Contact" icon="mail" href="mailto:dev@design4.pro">
+    Direct email support for inquiries
+  </Card>
+</CardGroup>

--- a/docs/languages/polish.mdx
+++ b/docs/languages/polish.mdx
@@ -1,0 +1,83 @@
+---
+title: Polish (pl)
+description: Polish language package for OpenCart
+sidebar_position: 10
+---
+
+# Polish Language
+
+Complete Polish language package for OpenCart, developed by DESIGN4PRO. Provides full translations for the admin panel and catalog (storefront).
+
+## Version Compatibility
+
+<CardGroup cols={1}>
+  <Card title="OpenCart 4.1.x" icon="check">
+    Full support - Latest and only supported version
+  </Card>
+</CardGroup>
+
+## Download
+
+[Download Polish language package v4.1](/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip)
+
+## Features
+
+- Complete admin panel translation (100%)
+- Complete catalog translation (100%)
+- Email templates translation
+- Extension translations
+- System messages translation
+- Installation support
+- Regular updates
+
+<Note>
+The Polish language package is actively maintained and updated with each new OpenCart release.
+</Note>
+
+## Translation Coverage
+
+| Component | Coverage |
+|-----------|----------|
+| Admin Panel | 100% |
+| Catalog | 100% |
+| Extensions | 100% |
+| System Messages | 100% |
+| Email Templates | 100% |
+
+## What's Included
+
+The package includes translations for:
+
+- Admin panel interface (all pages)
+- Catalog storefront (all pages)
+- Email notifications
+- Error messages
+- System notifications
+- Extension pages
+
+## Purchase
+
+<CardGroup cols={2}>
+  <Card title="OpenCart Marketplace" icon="shopping-cart" href="https://www.opencart.com/index.php?route=marketplace extension/info&extension_id=436503" target="_blank">
+    Purchase from official OpenCart Marketplace
+  </Card>
+  <Card title="Direct Download" icon="download" href="/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip" target="_blank">
+    Download directly - Free
+  </Card>
+</CardGroup>
+
+<Info>
+Purchasing from OpenCart Marketplace supports the development and provides access to updates through the marketplace.
+</Info>
+
+## Support
+
+For support and updates:
+
+- **Bug Reports**: [GitHub Issues](https://github.com/design4pro/opencart/issues)
+- Email: dev@design4.pro
+- Website: https://design4.pro
+
+<Check>
+Polish language package is production-ready and used by thousands of OpenCart stores in Poland.
+</Check>

--- a/docs/pl/development/building.mdx
+++ b/docs/pl/development/building.mdx
@@ -1,0 +1,170 @@
+---
+title: Budowanie Pakietów
+description: Jak budować pakiety językowe ze źródeł
+sidebar_position: 20
+---
+
+# Budowanie Pakietów
+
+Dowiedz się, jak budować pakiety językowe ze plików źródłowych przy użyciu systemu budowania.
+
+## Wymagania Wstępne
+
+- Node.js w wersji 18 lub wyższej
+- Menadżer pakietów npm lub yarn
+
+## Instalacja
+
+<CodeGroup>
+```bash npm
+npm install
+```
+
+```bash yarn
+yarn install
+```
+</CodeGroup>
+
+## Budowanie Pakietów
+
+### Buduj Wszystkie Pakiety
+
+Zbuduj wszystkie pakiety językowe dla domyślnej wersji:
+
+```bash
+npm run build
+```
+
+### Buduj Określony Język
+
+Zbuduj tylko pakiet określonego języka:
+
+```bash
+npm run build:pl
+```
+
+### Buduj Wszystkie Języki
+
+Zbuduj wszystkie pakiety językowe dla wszystkich wersji:
+
+```bash
+npm run build:all
+```
+
+## Wynik
+
+Zbudowane pakiety są zapisywane w katalogu `packages/`:
+
+```
+packages/
+├── pl/
+│   ├── v4.1/
+│   │   └── opencart-core-language-pl-v4.1.ocmod.zip
+│   ├── v4.0/
+│   └── v3/
+├── fr/
+└── ...
+```
+
+<Note>
+Każdy pakiet jest nazwany zgodnie z konwencją: `opencart-core-language-{lang}-{version}.ocmod.zip`
+</Note>
+
+## Struktura Pakietu
+
+Każdy pakiet ZIP zawiera:
+
+```
+opencart-core-language-{lang}-{version}.ocmod.zip
+├── install.json
+├── admin/
+│   └── language/
+│       ├── en-gb/
+│       └── {language}/
+└── catalog/
+    └── language/
+        ├── en-gb/
+        └── {language}/
+```
+
+## Szablon Rozszerzenia
+
+Wielokrotnie używalny szablon do tworzenia rozszerzeń językowych OpenCart znajduje się w:
+
+```
+sources/v4.1/extension/template/design4pro/
+```
+
+### Struktura Szablonu
+
+```
+design4pro/
+├── install.json
+└── admin/
+    ├── controller/dashboard/language_xx.php
+    ├── model/dashboard/language_xx.php    # Konfigurowalne stałe
+    ├── view/template/dashboard/language_xx.twig
+    └── language/
+        ├── en-gb/language_xx.php
+        └── pl-pl/language_xx.php
+```
+
+### Używanie Szablonu
+
+<Steps>
+  <Step title="Kopiuj Szablon">
+    Skopiuj folder `design4pro` do nowego katalogu języka (np. `language_de/`)
+  </Step>
+  <Step title="Zmień Nazwy Plików">
+    Zmień nazwy wszystkich plików `language_xx` na swój kod języka:
+    - `language_xx.php` → `language_de.php`
+    - `language_xx.twig` → `language_de.twig`
+  </Step>
+  <Step title="Skonfiguruj Stałe">
+   Zmodyfikuj stałe w `model/dashboard/language_de.php`:
+    - `LANGUAGE_CODE` - format regionalny (np. `'de-de'`)
+    - `LANGUAGE_NAME` - nazwa języka
+    - `COUNTRY_CODE`, `CURRENCY_CODE`, `TAX_RATE_PERCENT`
+    - `ZONES` - tablica regionów/prowincji
+    - Słowniki tłumaczeń
+  </Step>
+  <Step title="Zaktualizuj Folder Języka">
+    Zmień nazwę folderu języka z `pl-pl` na swój kod (np. `de-de`)
+  </Step>
+  <Step title="Tłumacz">
+    Przetłumacz `admin/language/{code}/language_de.php`
+  </Step>
+  <Step title="Zaktualizuj Metadane">
+    Zaktualizuj `install.json` ze szczegółami swojego języka
+  </Step>
+</Steps>
+
+<Warning>
+Użyj kodu języka w nazwie rozszerzenia: `language_pl`, `language_de` itp. Zapobiega to konfliktom przy instalacji wielu języków.
+</Warning>
+
+## Ważne Uwagi
+
+<Tabs>
+  <Tab title="Kody Języków">
+    Użyj regionalnego formatu kodów języków:
+    - Polski: `pl-pl`
+    - Niemiecki: `de-de`
+    - Hiszpański: `es-es`
+
+    OpenCart 4.x wymaga tego formatu dla właściwego wykrywania języka.
+  </Tab>
+  <Tab title="Funkcje Szablonu">
+    Szablon obsługuje:
+    - Instalację języka
+    - Konfigurację waluty
+    - Ustawienia kraju
+    - Ustawienia stref/prowincji
+    - Stawki podatkowe
+    - Słowniki tłumaczeń
+  </Tab>
+</Tabs>
+
+<Check>
+Twoje rozszerzenie językowe jest teraz gotowe do instalacji przez instalator rozszerzeń OpenCart.
+</Check>

--- a/docs/pl/development/translating.mdx
+++ b/docs/pl/development/translating.mdx
@@ -1,0 +1,151 @@
+---
+title: Tłumaczenie
+description: Jak tłumaczyć pliki językowe za pomocą Claude Code
+sidebar_position: 21
+---
+
+# Tłumaczenie Plików Językowych
+
+Ten projekt używa skillu Claude Code do efektywnego i dokładnego tłumaczenia plików językowych OpenCart.
+
+## Dostępne Języki
+
+<CardGroup cols={3}>
+  <Card title="Polski (pl-pl)" icon="check">
+    Pełne tłumaczenie dostępne
+  </Card>
+  <Card title="Francuski (fr-fr)" icon="hammer">
+    Tłumaczenie w trakcie
+  </Card>
+  <Card title="Niemiecki (de-de)" icon="globe">
+    Wkrótce
+  </Card>
+  <Card title="Włoski (it-it)" icon="globe">
+    Wkrótce
+  </Card>
+  <Card title="Ukraiński (uk-ua)" icon="globe">
+    Wkrótce
+  </Card>
+  <Card title="Hiszpański (es-es)" icon="globe">
+    Wkrótce
+  </Card>
+</CardGroup>
+
+## Jak Tłumaczyć
+
+### Używanie Poleceń Claude Code
+
+<Steps>
+  <Step title="Otwórz Claude Code">
+    Otwórz Claude Code w katalogu projektu
+  </Step>
+  <Step title="Użyj Skilla Tłumaczenia">
+    Użyj skillu OpenCart Language Translator z desired językiem i zakresem
+  </Step>
+  <Step title="Czekaj na Zakończenie">
+    Agent przetworzy wszystkie pliki i wygeneruje tłumaczenia
+  </Step>
+</Steps>
+
+### Przykładowe Polecenia
+
+Tłumacz pliki językowe administratora na niemiecki:
+
+```
+/translate admin language to german for v4.1
+```
+
+Tłumacz pliki językowe sklepu na francuski:
+
+```
+/translate catalog language files to french
+```
+
+### Bezpośrednie Prośby
+
+Możesz też pytać bezpośrednio:
+
+- "Przetłumacz pliki językowe admin na niemiecki dla v4.1"
+- "Translate catalog language files to French"
+- "Translate all extension files to Spanish"
+
+<Info>
+Agent tłumaczący używa AI do zapewnienia wysokiej jakości, kontekstowych tłumaczeń dla wszystkich plików językowych.
+</Info>
+
+## Przepływ Pracy Tłumaczenia
+
+<Steps>
+  <Step title="Pliki Źródłowe">
+    Angielskie pliki źródłowe znajdują się w `sources/{version}/`
+  </Step>
+  <Step title="Proces Tłumaczenia">
+    Claude Code przetwarza każdy plik i generuje tłumaczenia za pomocą AI
+  </Step>
+  <Step title="Wynik Tłumaczenia">
+    Przetłumaczone pliki są zapisywane w `translations/{lang}/{version}/`
+  </Step>
+  <Step title="Zbuduj Pakiet">
+    Użyj `npm run build` do utworzenia pakietu
+  </Step>
+</Steps>
+
+## Struktura Plików
+
+### Pliki Źródłowe
+
+```
+sources/
+├── v4.1/
+│   ├── admin/           # Angielskie pliki panelu administratora
+│   │   ├── catalog/
+│   │   ├── common/
+│   │   └── ...
+│   └── catalog/         # Angielskie pliki sklepu
+│       ├── account/
+│       ├── checkout/
+│       └── ...
+├── v4.0/
+└── v3/
+```
+
+### Przetłumaczone Pliki
+
+```
+translations/
+├── pl/
+│   ├── v4.1/
+│   │   ├── admin/      # Polskie tłumaczenia administratora
+│   │   └── catalog/   # Polskie tłumaczenia sklepu
+│   ├── v4.0/
+│   └── v3/
+├── fr/
+└── ...
+```
+
+## Pokrycie Tłumaczeń
+
+| Komponent | Status |
+|-----------|--------|
+| Panel Administratora | Pełne pokrycie |
+| Sklep | Pełne pokrycie |
+| Rozszerzenia | Pełne pokrycie |
+| Komunikaty Systemowe | Pełne pokrycie |
+
+<Check>
+Wszystkie tłumaczenia utrzymują 100% kompatybilność z plikami źródłowymi.
+</Check>
+
+## Najlepsze Praktyki
+
+<Tip>
+Dodając nowe tłumaczenia:
+1. Zawsze używaj regionalnego formatu kodu języka (pl-pl, de-de, es-es)
+2. Postępuj zgodnie z istniejącymi konwencjami tłumaczeń OpenCart
+3. Testuj tłumaczenia zarówno w adminie, jak i w sklepie
+4. Zbuduj i zainstaluj pakiet, aby zweryfikować
+</Tip>
+
+## Potrzebujesz Pomocy?
+
+W sprawach tłumaczeń lub aby wnieść nowe języki, skontaktuj się: dev@design4.pro

--- a/docs/pl/getting-started/installation.mdx
+++ b/docs/pl/getting-started/installation.mdx
@@ -1,0 +1,107 @@
+---
+title: Instalacja
+description: Jak zainstalować pakiety językowe OpenCart
+sidebar_position: 2
+---
+
+# Instalacja
+
+## Wymagania
+
+- OpenCart 3.x, 4.0.x lub 4.1.x
+- Dostęp do panelu administratora OpenCart
+
+<Info>
+Zalecamy użycie metody instalatora rozszerzeń dla najłatwiejszej instalacji i przyszłych aktualizacji.
+</Info>
+
+## Metody Instalacji
+
+### Metoda 1: Instalator Rozszerzeń (Zalecana)
+
+<Steps>
+  <Step title="Pobierz Pakiet Językowy">
+    Pobierz pakiet językowy (plik .ocmod.zip) z katalogu pakietów
+  </Step>
+  <Step title="Prześlij do OpenCart">
+    Przejdź do **Rozszerzenia > Instalator** w panelu administratora
+  </Step>
+  <Step title="Zainstaluj Pakiet">
+    Kliknij przycisk **Prześlij** i wybierz pobrany plik ZIP
+  </Step>
+  <Step title="Włącz Język">
+    Przejdź do **Rozszerzenia > Rozszerzenia > Języki**, znajdź swój język i kliknij Zainstaluj
+  </Step>
+  <Step title="Skonfiguruj Ustawienia">
+    Kliknij Edytuj, aby skonfigurować ustawienia języka
+  </Step>
+</Steps>
+
+### Metoda 2: Instalacja Ręczna
+
+<Steps>
+  <Step title="Wypakuj Plik ZIP">
+    Wypakuj pobrany plik ZIP na komputerze lokalnym
+  </Step>
+  <Step title="Prześlij Pliki">
+    Prześlij foldery `admin` i `catalog` do głównego katalogu OpenCart
+  </Step>
+  <Step title="Zainstaluj Język">
+    Przejdź do **Rozszerzenia > Rozszerzenia > Języki** i zainstaluj swój język
+  </Step>
+  <Step title="Skonfiguruj Ustawienia">
+    Kliknij Edytuj, aby skonfigurować ustawienia języka
+  </Step>
+</Steps>
+
+<Warning>
+Ręczna instalacja może powodować problemy z przyszłymi aktualizacjami. Zalecamy użycie instalatora rozszerzeń.
+</Warning>
+
+## Konfiguracja
+
+Po instalacji skonfiguruj język:
+
+<Steps>
+  <Step title="Przejdź do Języków">
+    Przejdź do **System > Lokalizacja > Języki**
+  </Step>
+  <Step title="Edytuj Język">
+    Kliknij **Edytuj** przy swoim nowym języku
+  </Step>
+  <Step title="Włącz Język">
+    Ustaw **Status** na Włączony
+  </Step>
+  <Step title="Ustaw Kolejność Sortowania">
+    Ustaw **Kolejność sortowania** na 1 (lub inną preferowaną)
+  </Step>
+  <Step title="Zapisz Zmiany">
+    Kliknij przycisk Zapisz, aby zastosować zmiany
+  </Step>
+</Steps>
+
+## Ustawienie Języka Domyślnego
+
+Aby ustawić nowy język jako domyślny język sklepu:
+
+<Steps>
+  <Step title="Otwórz Ustawienia">
+    Przejdź do **System > Ustawienia**
+  </Step>
+  <Step title="Edytuj Sklep">
+    Kliknij **Edytuj** przy swoim sklepie
+  </Step>
+  <Step title="Przejdź do Zakładki Lokalne">
+    Nawiguj do zakładki **Lokalne**
+  </Step>
+  <Step title="Ustaw Język Domyślny">
+    Ustaw **Język** na swój nowy język
+  </Step>
+  <Step title="Zapisz Ustawienia">
+    Kliknij Zapisz, aby zastosować zmiany
+  </Step>
+</Steps>
+
+<Check>
+Twój język jest teraz zainstalowany i skonfigurowany. Sklep będzie wyświetlany w nowym języku dla wszystkich odwiedzających.
+</Check>

--- a/docs/pl/getting-started/purchase.mdx
+++ b/docs/pl/getting-started/purchase.mdx
@@ -1,0 +1,79 @@
+---
+title: Zakup
+description: Zakup pakietów językowych z OpenCart Marketplace
+sidebar_position: 3
+---
+
+# Zakup Pakietów Językowych
+
+Możesz uzyskać nasze pakiety językowe na dwa sposoby: przez oficjalny OpenCart Marketplace lub przez bezpośrednie pobieranie.
+
+## OpenCart Marketplace
+
+<Card title="Pakiet Języka Polskiego" icon="shopping-cart" href="https://www.opencart.com/index.php?route=marketplace extension/info&extension_id=436503" target="_blank">
+  Zakup z OpenCart Marketplace
+</Card>
+
+### Zalety Zakupu z Marketplace
+
+<CardGroup cols={2}>
+  <Card title="Łatwe Aktualizacje" icon="refresh">
+    Otrzymuj aktualizacje bezpośrednio przez menedżer rozszerzeń OpenCart
+  </Card>
+  <Card title="Bezpieczna Płatność" icon="lock">
+    Bezpieczne transakcje przez system płatności OpenCart
+  </Card>
+  <Card title="Zarządzanie Licencją" icon="file-text">
+    Automatyczna walidacja i zarządzanie licencją
+  </Card>
+  <Card title="Dostęp do Wsparcia" icon="headphones">
+    Priorytetowe wsparcie dla zakupów z marketplace
+  </Card>
+</CardGroup>
+
+### Co Otrzymujesz
+
+- Pełny dostęp do pakietu języka polskiego
+- Aktualizacje przyszłych wersji
+- Wsparcie rozszerzenia
+- Pomoc przy instalacji
+
+## Pobieranie Bezpośrednie
+
+Pobierz pakiety językowe bezpośrednio z naszych serwerów za darmo:
+
+<Tabs>
+  <Tab title="OpenCart 4.1">
+    [Pobierz pakiet języka polskiego v4.1](/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 4.0">
+    [Pobierz pakiet języka polskiego v4.0](/packages/pl/v4.0/opencart-core-language-pl-v4.0.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 3">
+    [Pobierz pakiet języka polskiego v3](/packages/pl/v3/opencart-core-language-pl-v3.ocmod.zip)
+  </Tab>
+</Tabs>
+
+### Funkcje Pobierania Bezpośredniego
+
+- Bezpłatny dostęp do wszystkich pakietów językowych
+- Wymagana ręczna instalacja
+- Samodzielne zarządzanie aktualizacjami
+- Wsparcie społeczności przez GitHub
+
+<Warning>
+Pobieranie bezpośrednie nie obejmuje automatycznych aktualizacji. Będziesz musiał ręcznie sprawdzać i instalować nowe wersje.
+</Warning>
+
+## Porównanie
+
+| Funkcja | Marketplace | Pobieranie Bezpośrednie |
+|---------|-------------|------------------------|
+| Cena | Płatny | Bezpłatny |
+| Auto Aktualizacje | Tak | Nie |
+| Wsparcie | Priorytetowe | Społeczność |
+| Instalacja | Jednym kliknięciem | Ręczna |
+
+<Tip>
+Wybierz opcję najlepiej dopasowaną do Twoich potrzeb. Obie opcje oferują tę samą zawartość pakietu językowego.
+</Tip>

--- a/docs/pl/getting-started/support.mdx
+++ b/docs/pl/getting-started/support.mdx
@@ -1,0 +1,117 @@
+---
+title: Wsparcie
+description: Uzyskaj wsparcie i zgłoś błędy przez GitHub Issues
+sidebar_position: 4
+---
+
+# Wsparcie i Zgłaszanie Błędów
+
+Zapraszamy do zgłaszania błędów i propozycji funkcji. Użyj GitHub Issues do zgłaszania wszelkich napotkanych problemów.
+
+## Zgłoś Błąd
+
+<Card title="Otwórz GitHub Issues" icon="bug" href="https://github.com/design4pro/opencart/issues" target="_blank">
+  Zgłoś błędy i problemy
+</Card>
+
+### Przed Przesłaniem
+
+<Steps>
+  <Step title="Wyszukaj Istniejące Problemy">
+    Sprawdź, czy problem nie został już zgłoszony
+  </Step>
+  <Step title="Zweryfikuj Problem">
+    Potwierdź, że problem istnieje w najnowszej wersji
+  </Step>
+  <Step title="Zbierz Informacje">
+    Zbierz istotne informacje o Twoim środowisku
+  </Step>
+</Steps>
+
+### Wymagane Informacje
+
+Zgłaszając błąd, prosimy o dołączenie:
+
+<Accordion title="Szczegóły Środowiska">
+- Wersja OpenCart
+- Wersja PHP
+- Serwer WWW (Apache/Nginx)
+- Wersja bazy danych
+- Wersja pakietu językowego
+</Accordion>
+
+<Accordion title="Opis Problemu">
+- Jasny opis problemu
+- Kroki do odtworzenia
+- Oczekiwane vs rzeczywiste zachowanie
+</Accordion>
+
+<Accordion title="Zrzuty Ekranu">
+- Odpowiednie zrzuty ekranu
+- Komunikaty błędów
+- Logi konsoli (jeśli dotyczy)
+</Accordion>
+
+### Szablon Zgłoszenia Błędu
+
+```markdown
+**Opis Błędu**
+[Jasny i zwięzły opis błędu]
+
+**Środowisko**
+- Wersja OpenCart:
+- Wersja PHP:
+- Wersja Pakietu Językowego:
+
+**Kroki do Odtworzenia**
+1. Idź do '...'
+2. Kliknij na '....'
+3. Zobacz błąd
+
+**Oczekiwane Zachowanie**
+[Co spodziewałeś się, że się stanie]
+
+**Rzeczywiste Zachowanie**
+[Co faktycznie się stało]
+
+**Zrzuty Ekranu**
+[Jeśli dotyczy, dodaj zrzuty ekranu]
+```
+
+## Propozycje Funkcji
+
+<Card title="Poproś o Funkcję" icon="lightbulb" href="https://github.com/design4pro/opencart/issues" target="_blank">
+  Prześlij propozycje funkcji
+</Card>
+
+### Szablon Propozycji Funkcji
+
+```markdown
+**Opis Funkcji**
+[Jasny opis funkcji]
+
+**Przypadek Użycia**
+[Wytłumacz, dlaczego ta funkcja byłaby przydatna]
+
+**Proponowane Rozwiązanie**
+[Twój pomysł na implementację]
+```
+
+## Inne Kanały Wsparcia
+
+<CardGroup cols={2}>
+  <Card title="Wsparcie E-mail" icon="mail" href="mailto:dev@design4.pro">
+    Bezpośrednie zapytania
+  </Card>
+  <Card title="Repozytorium GitHub" icon="github" href="https://github.com/design4pro/opencart" target="_blank">
+    Kod źródłowy i wkład
+  </Card>
+</CardGroup>
+
+<Warning>
+W przypadku luk w zabezpieczeniach nie zgłaszaj ich przez GitHub Issues. Wyślij w вопросy bezpieczeństwa bezpośrednio na adres dev@design4.pro.
+</Warning>
+
+<Tip>
+Przed przesłaniem zgłoszenia błędu sprawdź istniejące problemy i pull requesty, aby uniknąć duplikatów.
+</Tip>

--- a/docs/pl/languages/polish.mdx
+++ b/docs/pl/languages/polish.mdx
@@ -1,0 +1,99 @@
+---
+title: Polski (pl)
+description: Pakiet języka polskiego dla OpenCart
+sidebar_position: 10
+---
+
+# Język Polski
+
+Kompletny pakiet języka polskiego dla OpenCart, opracowany przez DESIGN4PRO. Oferuje pełne tłumaczenia panelu administratora i sklepu (catalog).
+
+## Kompatybilność Wersji
+
+<CardGroup cols={3}>
+  <Card title="OpenCart 4.1.x" icon="check">
+    Pełne wsparcie - Najnowsza wersja
+  </Card>
+  <Card title="OpenCart 4.0.x" icon="check">
+    Wsparcie legacy dostępne
+  </Card>
+  <Card title="OpenCart 3.x" icon="check">
+    Wsparcie legacy dostępne
+  </Card>
+</CardGroup>
+
+## Pobieranie
+
+<Tabs>
+  <Tab title="OpenCart 4.1">
+    [Pobierz pakiet języka polskiego v4.1](/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 4.0">
+    [Pobierz pakiet języka polskiego v4.0](/packages/pl/v4.0/opencart-core-language-pl-v4.0.ocmod.zip)
+  </Tab>
+  <Tab title="OpenCart 3">
+    [Pobierz pakiet języka polskiego v3](/packages/pl/v3/opencart-core-language-pl-v3.ocmod.zip)
+  </Tab>
+</Tabs>
+
+## Funkcje
+
+- Kompletne tłumaczenie panelu administratora (100%)
+- Kompletne tłumaczenie sklepu (100%)
+- Tłumaczenie szablonów e-mail
+- Tłumaczenia rozszerzeń
+- Tłumaczenia komunikatów systemowych
+- Wsparcie instalacji
+- Regularne aktualizacje
+
+<Note>
+Pakiet języka polskiego jest aktywnie utrzymywany i aktualizowany przy każdym nowym wydaniu OpenCart.
+</Note>
+
+## Pokrycie Tłumaczeń
+
+| Komponent | Pokrycie |
+|-----------|----------|
+| Panel Administratora | 100% |
+| Sklep (Catalog) | 100% |
+| Rozszerzenia | 100% |
+| Komunikaty Systemowe | 100% |
+| Szablony E-mail | 100% |
+
+## Co Zawiera Pakiet
+
+Pakiet zawiera tłumaczenia dla:
+
+- Interfejs panelu administratora (wszystkie strony)
+- Sklep (wszystkie strony)
+- Powiadomienia e-mail
+- Komunikaty błędów
+- Powiadomienia systemowe
+- Strony rozszerzeń
+
+## Zakup
+
+<CardGroup cols={2}>
+  <Card title="OpenCart Marketplace" icon="shopping-cart" href="https://www.opencart.com/index.php?route=marketplace extension/info&extension_id=436503" target="_blank">
+    Zakup z oficjalnego OpenCart Marketplace
+  </Card>
+  <Card title="Pobieranie Bezpośrednie" icon="download" href="/packages/pl/v4.1/opencart-core-language-pl-v4.1.ocmod.zip">
+    Pobierz bezpośrednio - Bezpłatnie
+  </Card>
+</CardGroup>
+
+<Info>
+Zakup z OpenCart Marketplace wspiera rozwój i zapewnia dostęp do aktualizacji przez marketplace.
+</Info>
+
+## Wsparcie
+
+Aby uzyskać wsparcie i aktualizacje:
+
+- **Zgłaszanie Błędów**: [GitHub Issues](https://github.com/design4pro/opencart/issues)
+- E-mail: dev@design4.pro
+- Strona: https://design4.pro
+
+<Check>
+Pakiet języka polskiego jest gotowy do produkcji i jest używany przez tysiące sklepów OpenCart w Polsce.
+</Check>

--- a/docs/pl/overview.mdx
+++ b/docs/pl/overview.mdx
@@ -1,0 +1,119 @@
+---
+title: Przegląd
+description: Pakiety wielojęzyczne dla platformy e-commerce OpenCart
+sidebar_position: 1
+---
+
+# OpenCart Languages
+
+Witamy w dokumentacji OpenCart Languages. Ten projekt dostarcza pakiety wielojęzyczne dla platformy e-commerce OpenCart, opracowane i utrzymywane przez DESIGN4PRO.
+
+## Obsługiwane Języki
+
+<CardGroup cols={3}>
+  <Card title="Polski (pl-pl)" icon="globe" href="/pl/languages/polish">
+    Kompletny pakiet języka polskiego dla OpenCart 4.1.x
+  </Card>
+  <Card title="Francuski (fr-fr)" icon="globe" badge={{ label: 'Wkrótce', variant: 'warning' }}>
+    Pakiet języka francuskiego - wkrótce dostępny
+  </Card>
+  <Card title="Niemiecki (de-de)" icon="globe" badge={{ label: 'Wkrótce', variant: 'warning' }}>
+    Pakiet języka niemieckiego - wkrótce dostępny
+  </Card>
+  <Card title="Włoski (it-it)" icon="globe" badge={{ label: 'Wkrótce', variant: 'warning' }}>
+    Pakiet języka włoskiego - wkrótce dostępny
+  </Card>
+  <Card title="Ukraiński (uk-ua)" icon="globe" badge={{ label: 'Wkrótce', variant: 'warning' }}>
+    Pakiet języka ukraińskiego - wkrótce dostępny
+  </Card>
+  <Card title="Hiszpański (es-es)" icon="globe" badge={{ label: 'Wkrótce', variant: 'warning' }}>
+    Pakiet języka hiszpańskiego - wkrótce dostępny
+  </Card>
+</CardGroup>
+
+## Obsługiwane Wersje OpenCart
+
+<Tabs>
+  <Tab title="OpenCart 4.1.x">
+    Aktualna stabilna wersja z pełnym wsparciem językowym
+  </Tab>
+  <Tab title="OpenCart 4.0.x">
+    Wsparcie legacy dostępne
+  </Tab>
+  <Tab title="OpenCart 3.x">
+    Wsparcie legacy dostępne
+  </Tab>
+</Tabs>
+
+## Szybki Start
+
+<Steps>
+  <Step title="Pobierz Pakiet Językowy">
+    Pobierz pakiet językowy dla Twojej wersji OpenCart z katalogu pakietów
+  </Step>
+  <Step title="Zainstaluj przez Instalator Rozszerzeń">
+    Przejdź do sekcji Rozszerzenia > Instalator w panelu administratora i prześlij plik ZIP
+  </Step>
+  <Step title="Skonfiguruj Język">
+    Przejdź do sekcji System > Lokalizacja > Języki i skonfiguruj nowy język
+  </Step>
+  <Step title="Ustaw jako Domyślny">
+    Opcjonalnie ustaw nowy język jako domyślny w sekcji System > Ustawienia > Lokalne
+  </Step>
+</Steps>
+
+## Funkcje
+
+- Kompletne tłumaczenia panelu administratora
+- Kompletne tłumaczenia sklepu (catalog)
+- Tłumaczenia szablonów e-mail
+- Regularne aktualizacje dla nowych wersji OpenCart
+- Profesjonalna lokalizacja przez DESIGN4PRO
+- Wielokrotnie używalny szablon rozszerzenia dla nowych języków
+
+<Note>
+Wszystkie pakiety językowe zawierają pełne tłumaczenia administratora i sklepu ze 100% pokryciem dla maksymalnej kompatybilności.
+</Note>
+
+## Szablon Rozszerzenia Językowego
+
+Wielokrotnie używalny szablon do tworzenia rozszerzeń językowych OpenCart znajduje się w:
+
+```
+sources/v4.1/extension/template/design4pro/
+```
+
+Szablon zawiera:
+
+- Sparametryzowany model z konfigurowalnymi stałymi
+- Wsparcie dla regionalnych kodów języka (pl-pl, de-de itp.)
+- Automatyczna instalacja języka, waluty, kraju i stref
+- Słowniki tłumaczeń dla statusów, opcji, układów i nie tylko
+
+<Tip>
+Użyj szablonu rozszerzenia, aby szybko i spójnie tworzyć własne pakiety językowe.
+</Tip>
+
+Zobacz dokumentację [Budowanie Pakietów](/pl/development/building), aby uzyskać szczegóły na temat używania szablonu.
+
+## Zakup
+
+<CardGroup cols={2}>
+  <Card title="OpenCart Marketplace" icon="shopping-cart" href="/pl/getting-started/purchase">
+    Zakup pakiety językowe z oficjalnego OpenCart Marketplace
+  </Card>
+  <Card title="Pobieranie Bezpośrednie" icon="download" href="/pl/languages/polish">
+    Pobierz pakiety językowe bezpośrednio z naszych serwerów
+  </Card>
+</CardGroup>
+
+## Pomoc Techniczna
+
+<CardGroup cols={2}>
+  <Card title="Zgłoś Błędy" icon="bug" href="/pl/getting-started/support">
+    Znalazłeś błąd? Zgłoś błędy przez GitHub Issues
+  </Card>
+  <Card title="Kontakt" icon="mail" href="mailto:dev@design4.pro">
+    Bezpośredni kontakt e-mail
+  </Card>
+</CardGroup>


### PR DESCRIPTION
- Update docs.json navigation from dropdowns to tabs pattern
- Fix polish.mdx to only list OpenCart 4.1.x (remove 4.0.x and 3.x)
- Fix installation.mdx requirements to specify only 4.1.x
- Update CLAUDE.md with accurate extension structure and commands