### PR TITLE
fix(ci): pin zensical version to fix build error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install zensical
+      - run: pip install zensical==0.0.25
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
Zensical 0.0.27 has a bug in config.rs that causes build failure. Pinning to 0.0.25 which works correctly.