### PR TITLE
fix(ci): use Python 3.12 to fix zensical build error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: "3.12"
       - run: pip install zensical==0.0.25
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- Change Python version from 3.x to 3.12 to fix zensical build error
- Pin zensical to 0.0.25 version

## Test plan
- [ ] Check if GitHub Actions workflow passes