### PR TITLE
fix(ci): try building zensical from source with version 0.0.24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install zensical==0.0.25
+      - run: pip install --no-binary zensical zensical==0.0.24
       - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Try building zensical from source instead of using pre-built wheel
- Use version 0.0.24

## Test plan
- [ ] Check if GitHub Actions workflow passes