### PR TITLE
fix(ci): switch from zensical to mkdocs-material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install --no-binary zensical zensical==0.0.24
-      - run: zensical build --clean
+      - run: pip install mkdocs-material
+      - run: mkdocs build
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site


### PR DESCRIPTION
## Summary
- Replace zensical with mkdocs-material due to persistent build errors
- Zensical has a bug causing "No such file or directory" error in config.rs

## Test plan
- [ ] Check if GitHub Actions workflow passes