### PR TITLE
fix(ci): copy index.html to root after build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: "3.12"
       - run: pip install mkdocs-material
       - run: mkdocs build
+      - run: cp site/en/index.html site/index.html
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site


### PR DESCRIPTION
## Summary
- Add step to copy index.html to site root after mkdocs build
- This fixes 404 error on root path